### PR TITLE
Make the order process work globally

### DIFF
--- a/modules/addons/hooks.php
+++ b/modules/addons/hooks.php
@@ -1,0 +1,22 @@
+<?php
+
+if (!defined("WHMCS"))
+	die("This file cannot be accessed directly");
+
+use Illuminate\Database\Capsule\Manager as Capsule;
+
+// skip checking for fraud order
+function moneroEnable ( $vars ) {
+	$opt1 = Capsule::select("SELECT `value` FROM tbladdonmodules WHERE module = 'moneroEnable' AND setting = 'option1' LIMIT 1")[0]->value;
+	$opt2 = Capsule::select("SELECT `value` FROM tbladdonmodules WHERE module = 'moneroEnable' AND setting = 'option2' LIMIT 1")[0]->value;
+	if($opt1 == 'on' && $opt2 > '' && $vars['orderid'] > '') {
+		$pmtMet = Capsule::select("SELECT paymentmethod FROM tblorders WHERE id = ".$vars['orderid'])[0]->paymentmethod;
+		if($pmtMet > '') {
+			if($pmtMet == $opt2) return true;
+		}
+	}
+}
+
+add_hook("RunFraudCheck", 1, "moneroEnable");
+
+?>

--- a/modules/addons/moneroenable.php
+++ b/modules/addons/moneroenable.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Capsule\Manager as Capsule;
+
+
+function moneroEnable_config () {
+    $result = Capsule::select("SELECT gateway, `value` FROM tblpaymentgateways WHERE setting = 'name' GROUP BY gateway");
+    foreach($result as $row) {
+        $pays[] = $row->gateway;
+    }
+
+    $pays = implode(',', $pays);
+    
+    $configarray = array(
+        "name" => "Monero Enabler",
+        "description" => "This module will allow you to disable fraud checking for Monero Payments.",
+        "version" => "1.0",
+        "author" => "Monero",
+        "fields" => array(
+            "option1" => array ("FriendlyName" => "Enable Checking", "Type" => "yesno", "Size" => "25",
+                                  "Description" => "Enable checking for payment method by module", ),
+            "option2" => array ("FriendlyName" => "Disable on Method", "Type" => "dropdown", "Options" => $pays,
+                                  "Description" => "Select the Monero payment Gateway", ),
+        )
+    );
+
+    return $configarray;
+}
+
+?>


### PR DESCRIPTION
WHMCS has a fraud check to prevent accepting stolen credit cards and hence merchant chargebacks.  Since there can be no chargebacks in Monero, this module allows the fraud check to be disabled for the Monero payment gateway.  Without this, new client orders will fail.

Once uploaded into modules/addons/ you need to active Monero Enabler in WHMCS -> Setup -> Addon Modules.  Configure the module and select the Monero payment gateway.