### PR TITLE
disabling default discount

### DIFF
--- a/modules/gateways/monero.php
+++ b/modules/gateways/monero.php
@@ -23,7 +23,7 @@ function monero_Config(){
 		'daemon_port' => array('FriendlyName' => 'Wallet RPC Port','Type'  => 'text','Default' => '18081','Description' => ''),
 		'daemon_user' => array('FriendlyName' => 'Wallet RPC Username','Type'  => 'text','Default' => '','Description' => ''),
 		'daemon_pass' => array('FriendlyName' => 'Wallet RPC Password','Type'  => 'text','Default' => '','Description' => ''),
-		'discount_percentage' => array('FriendlyName' => 'Discount Percentage','Type'  => 'text','Default' => '5%','Description' => 'Percentage discount for paying with Monero.')
+		'discount_percentage' => array('FriendlyName' => 'Discount Percentage','Type'  => 'text','Default' => '0%','Description' => 'Percentage discount for paying with Monero.')
     );
 }
 


### PR DESCRIPTION
When a discount is used, invoices are not marked as Paid in WHMCS.  Settings discount to 0 to effectively disable until a fix is made.